### PR TITLE
Fix missing left border in the editor table

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aelf-website-next",
-  "version": "1.0.0",
+  "version": "2.10.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/components/CustomEditor/styles.module.scss
+++ b/src/components/CustomEditor/styles.module.scss
@@ -55,6 +55,9 @@
       font-weight: 600;
       font-size: 18px;
     }
+    .tc-table {
+      border-left: 1px solid;
+    }
   }
 }
 
@@ -121,6 +124,9 @@
     .codex-editor .ce-block h4 {
       font-weight: 600;
       font-size: 18px;
+    }
+    .tc-table {
+      border-left: 1px solid;
     }
   }
 }


### PR DESCRIPTION
1. Fix missing left border in the editor table. close #37 